### PR TITLE
防止反复登陆与GIF下载

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 * scrapy
 * requests 
 * pillow 
-* pypiwin32 // 可能需要 
+* pypiwin32 // 可能需要
+* imageio //下载gif时需要
 * 如果还缺少什么，一般直接pip install就可以了
 
 ### 使用方法

--- a/pixiv_beta/items.py
+++ b/pixiv_beta/items.py
@@ -15,3 +15,4 @@ class ImageItem(scrapy.Item):
     title = scrapy.Field()
     pid = scrapy.Field()
     referer = scrapy.Field()
+    is_gif = scrapy.Field()

--- a/pixiv_beta/middlewares.py
+++ b/pixiv_beta/middlewares.py
@@ -5,7 +5,19 @@
 # See documentation in:
 # http://doc.scrapy.org/en/latest/topics/spider-middleware.html
 
+
+from __future__ import absolute_import
+
+import os
+import os.path
+import logging
+import pickle
+
+from scrapy.http.cookies import CookieJar
+
+from scrapy.downloadermiddlewares.cookies import CookiesMiddleware
 from scrapy import signals
+from .settings import prj_dir
 
 
 class PixivBetaSpiderMiddleware(object):
@@ -54,3 +66,40 @@ class PixivBetaSpiderMiddleware(object):
 
     def spider_opened(self, spider):
         spider.logger.info('Spider opened: %s' % spider.name)
+
+    def process_request(self, request, spider):
+        #request.meta['proxy'] = "http://127.0.0.1:8118"
+        pass
+
+
+class PersistentCookiesMiddleware(CookiesMiddleware):
+    def __init__(self, debug=False):
+        super(PersistentCookiesMiddleware, self).__init__(debug)
+        self.load()
+
+    def process_response(self, request, response, spider):
+        # TODO: optimize so that we don't do it on every response
+        res = super(PersistentCookiesMiddleware, self).process_response(request, response, spider)
+        self.save()
+        return res
+
+    def getPersistenceFile(self):
+        return os.path.join(prj_dir, '.cookie')
+
+    def save(self):
+        logging.debug("Saving cookies to disk for reuse")
+        with open(self.getPersistenceFile(), "wb+") as f:
+            pickle.dump(self.jars, f)
+            f.flush()
+
+    def load(self):
+        filename = self.getPersistenceFile()
+        logging.debug("Trying to load cookies from file '{0}'".format(filename))
+        if not os.path.exists(filename):
+            logging.info("File '{0}' for cookie reload doesn't exist".format(filename))
+            return
+        if os.path.isfile(filename):
+            logging.info("File '{0}' is not a regular file".format(filename))
+
+            with open(filename, "rb") as f:
+                self.jars = pickle.load(f)

--- a/pixiv_beta/pipelines.py
+++ b/pixiv_beta/pipelines.py
@@ -54,12 +54,12 @@ class PixivBetaImagePipeline(FilesPipeline):
         from zipfile import ZipFile
         import imageio
         import shutil
-        zip = ZipFile(file)
-        zip_folder = file.replace('.zip', '')
-        zip.extractall(zip_folder)
-        with imageio.get_writer(file.replace('.zip', '.gif'), mode='I') as writer:
-            for f in os.listdir(zip_folder):
-                writer.append_data(imageio.imread(os.path.join(zip_folder, f)))
-                #TODO: GIF帧率未实现，目前使用默认帧率
+        with ZipFile(file) as zip:
+            zip_folder = file.replace('.zip', '')
+            zip.extractall(zip_folder)
+            with imageio.get_writer(file.replace('.zip', '.gif'), mode='I') as writer:
+                for f in os.listdir(zip_folder):
+                    writer.append_data(imageio.imread(os.path.join(zip_folder, f)))
+                    #TODO: GIF帧率未实现，目前使用默认帧率
         os.remove(file)
         shutil.rmtree(zip_folder, ignore_errors=True)

--- a/pixiv_beta/settings.py
+++ b/pixiv_beta/settings.py
@@ -93,7 +93,7 @@ IMAGES_MIN_WIDTH = cf.getint('IMG', 'MIN_WIDTH')
 IMAGES_MIN_HEIGHT = cf.getint('IMG', 'MIN_HEIGHT')
 IMAGES_URLS_FIELD = "img_url"
 
-IMAGES_STORE = os.path.expanduser(cf.get('IMG', 'STORE_PATH'))
+IMAGES_STORE = os.path.abspath(os.path.expanduser(cf.get('IMG', 'STORE_PATH')))
 if os.path.isfile(IMAGES_STORE):
     print("using the default path")
     now_time = str(int(time.time()))
@@ -101,6 +101,7 @@ if os.path.isfile(IMAGES_STORE):
     IMAGES_STORE = os.path.join(prj_dir, 'images_' + now_time)
 elif not os.path.exists(IMAGES_STORE):
     os.makedirs(IMAGES_STORE)
+FILES_STORE = IMAGES_STORE
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html
 #AUTOTHROTTLE_ENABLED = True

--- a/pixiv_beta/settings.py
+++ b/pixiv_beta/settings.py
@@ -70,9 +70,11 @@ DOWNLOAD_DELAY = 0.60
 
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
-#DOWNLOADER_MIDDLEWARES = {
+DOWNLOADER_MIDDLEWARES = {
 #    'pixiv_beta.middlewares.MyCustomDownloaderMiddleware': 543,
-#}
+    'scrapy.downloadermiddlewares.cookies.CookiesMiddleware': None,
+    'pixiv_beta.middlewares.PersistentCookiesMiddleware': 701,
+}
 
 # Enable or disable extensions
 # See http://scrapy.readthedocs.org/en/latest/topics/extensions.html

--- a/pixiv_beta/spiders/pixiv-beta.py
+++ b/pixiv_beta/spiders/pixiv-beta.py
@@ -258,7 +258,7 @@ class pixivSpider(Spider):
         img_item['title'] = img_title
         img_item['pid'] = str(pid)
         img_item['referer'] = response.url
-        self.data.append(ImgData(img_title, pid, r18, view, praise, response.meta.setdefault('collection', ''), img_height, img_width, is_gif))
+        self.data.append(ImgData(img_title, pid, r18, view, praise, response.meta.setdefault('collection', ''), img_height, img_width))
         yield img_item
 
     def multiImgPage(self, response):

--- a/pixiv_beta/spiders/pixiv-beta.py
+++ b/pixiv_beta/spiders/pixiv-beta.py
@@ -89,7 +89,11 @@ class pixivSpider(Spider):
 
     # 入口
     def start_requests(self):
-        return [scrapy.Request(self.start_urls[0], headers=self.header, callback=self.login )]
+        if os.path.isfile(os.path.join(prj_dir, '.cookie')):
+            #TODO: cookie不正确时跳转至login
+            return self.center(None)
+        else:
+            return [scrapy.Request(self.start_urls[0], headers=self.header, callback=self.login )]
 
     def login(self, response):
         index_request = requests.get('http://www.pixiv.net', headers=self.header)


### PR DESCRIPTION
1.保存Cookie从而避免反复登陆（导致Pixiv反复发送异常登录提醒）
2.初步支持gif下载（依赖imageio）